### PR TITLE
fix: corregir lectura de archivos xlsx y ods por conflicto de plugins de pyexcel

### DIFF
--- a/linkaform_api/upload_file.py
+++ b/linkaform_api/upload_file.py
@@ -9,8 +9,8 @@
 #
 #####
 import wget
-import pyexcel
-import time, re, requests
+import pyexcel, openpyxl
+import time, re, requests, zipfile, io
 from datetime import datetime
 from sys import argv
 import simplejson
@@ -42,32 +42,40 @@ class LoadFile:
         #sheet = pyexcel.get_sheet(file_name="bolsa.xlsx")
         if file_name:
             sheet = pyexcel.get_sheet(file_name = file_name)
-        if file_url:
+            records = sheet.array
+        elif file_url:
             try:
-                sheet = pyexcel.get_sheet(url = file_url)
+                sheet = pyexcel.get_sheet(url=file_url)
+                records = sheet.array
             except Exception:
                 response = requests.get(file_url)
                 content = response.content
 
                 if content[:2] == b'PK':
                     try:
-                        sheet = pyexcel.get_sheet(
-                            file_type='ods',
-                            file_content=content
-                        )
-                    except Exception:
-                        sheet = pyexcel.get_sheet(
-                            file_type='xlsx',
-                            file_content=content
-                        )
+                        with zipfile.ZipFile(io.BytesIO(content)) as z:
+                            names = z.namelist()
+
+                        if any(n.startswith('xl/') for n in names):
+                            # XLSX: usar openpyxl directo para evitar conflicto de plugins
+                            wb = openpyxl.load_workbook(io.BytesIO(content), data_only=True)
+                            ws = wb.active
+                            records = [[cell.value for cell in row] for row in ws.iter_rows()]
+                        elif 'META-INF/manifest.xml' in names:
+                            sheet = pyexcel.get_sheet(file_type='ods', file_content=content)
+                            records = sheet.array
+                        else:
+                            raise ValueError("Formato ZIP no reconocido")
+
+                    except zipfile.BadZipFile:
+                        raise ValueError("Archivo corrupto o formato no soportado")
+
                 elif content[:8] == b'\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1':
-                    sheet = pyexcel.get_sheet(
-                        file_type='xls',
-                        file_content=content
-                    )
+                    sheet = pyexcel.get_sheet(file_type='xls', file_content=content)
+                    records = sheet.array
                 else:
                     raise ValueError(f"Formato de archivo no reconocido")
-        records = sheet.array
+
         header = records.pop(0)
         try:
             header = [str(col).lower().replace(u'\xa0',u' ').strip().replace(' ', '_') for col in header]


### PR DESCRIPTION
## Corrección de lectura de archivos xlsx y ods por conflicto de plugins de pyexcel

### Problema
Al leer archivos desde una URL, `pyexcel` enrutaba incorrectamente los archivos `.xlsx` y `.ods` al plugin `pyexcel-xls` (xlrd) en lugar del plugin correspondiente, causando errores al intentar leerlos.
```
xlrd.biffh.XLRDError: Excel xlsx file; not supported
xlrd.biffh.XLRDError: Openoffice.org ODS file; not supported
```

### Causa raíz
`pyexcel-xls` se registra como handler de archivos con magic bytes `PK` (ZIP), ganando precedencia sobre `pyexcel-xlsx` y `pyexcel-ods`, sin importar la extensión real del archivo.

### Cambios
Se reemplazó la lectura directa por URL con un fallback que:
1. Descarga el archivo manualmente
2. Inspecciona los magic bytes para determinar el formato real
3. Para archivos ZIP (`PK`), inspecciona el contenido interno del ZIP para distinguir entre XLSX y ODS
4. Para XLSX usa `openpyxl` directamente, evitando el conflicto de plugins
5. Para ODS y XLS legítimo sigue usando `pyexcel`

### Comportamiento
| Caso | Antes | Después |
|---|---|---|
| `.xlsx` real | `XLRDError: Excel xlsx file; not supported` | ✅ Lee correctamente |
| `.ods` disfrazado de `.xls` | `XLRDError: Openoffice.org ODS file; not supported` | ✅ Lee correctamente |
| `.xls` legítimo | ✅ Funcionaba | ✅ Sigue funcionando |