### PR TITLE
feat: Se remueven prints con informacion del usuario

### DIFF
--- a/linkaform_api/utils.py
+++ b/linkaform_api/utils.py
@@ -523,8 +523,6 @@ class Cache:
         if api_key:
             if type(api_key) == bool:
                 api_key = self.settings.config.get('api_key')
-            print('api key', api_key)
-            print('api user', user)
             jwt = self.network.login(session, username=user, get_jwt=get_jwt, api_key=api_key, get_user=get_user)
         else:
             jwt = self.network.login(session, user, password, get_jwt=get_jwt, get_user=get_user)


### PR DESCRIPTION
**Eliminar sentencias print de depuración que exponían credenciales sensibles**

Se eliminan dos sentencias `print` de depuración que registraban las variables `api_key` y `user` en la salida estándar, lo cual representaba un riesgo de seguridad al exponer potencialmente credenciales sensibles en logs o en la consola.