### PR TITLE
Agrega endpoint y función utilitaria para compartir scripts

### DIFF
--- a/linkaform_api/urls.py
+++ b/linkaform_api/urls.py
@@ -139,7 +139,8 @@ class Api_url:
             'create_folder': {'url': self.dest_url + '/api/infosync/script_folder/', 'method':'POST'},
             'run_script': {'url': self.dest_url + '/api/infosync/scripts/run/', 'method':'POST'},
             'upload_script': {'url': self.dest_url + '/api/infosync/upload_script/', 'method': 'POST'},
-            'update_script': {'url': self.dest_url + '/api/infosync/scripts/{}/', 'method': 'PATCH'}
+            'update_script': {'url': self.dest_url + '/api/infosync/scripts/{}/', 'method': 'PATCH'},
+            'share_script': {'url': self.dest_url + '/api/infosync/file_shared/', 'method': 'PATCH'},
         }
 
     def get_users_url(self):

--- a/linkaform_api/utils.py
+++ b/linkaform_api/utils.py
@@ -1393,6 +1393,16 @@ class Cache:
             data = { 'objects': [ data_to_share, ] }
         r = self.network.dispatch(url=url, method=method, data=data, jwt_settings_key=jwt_settings_key)
         return r
+    
+    def share_script(self, data_to_share, unshare=False, jwt_settings_key=False):
+        url = self.api_url.script['share_script']['url']
+        method = self.api_url.script['share_script']['method']
+        if unshare:
+            data = { 'objects': [], 'deleted_objects': data_to_share }
+        else:
+            data = { 'objects': [ data_to_share, ] }
+        r = self.network.dispatch(url=url, method=method, data=data, jwt_settings_key=jwt_settings_key)
+        return r
 
     def find_record(self, db_cr, rec_id):
         mango_query = {


### PR DESCRIPTION
## ¿Qué cambia?

- Se agrega la ruta `share_script` en `Api_url.script` apuntando a `/api/infosync/file_shared/` con método `PATCH`.
- Se agrega el método `share_script` en la clase `Cache` dentro de `utils.py`, siguiendo el mismo patrón que el método `share_record` ya existente.
- El método acepta un parámetro `unshare` (booleano) para diferenciar entre compartir y dejar de compartir un script.

## ¿Por qué?

Hasta ahora la API no exponía funcionalidad para compartir scripts de Linkaform. Esta adición permite a los consumidores de la librería invocar el servicio de compartición de scripts de forma consistente con el resto de la API, reutilizando la infraestructura de red (`network.dispatch`) y de autenticación (`jwt_settings_key`) ya establecida.

## Notas adicionales

- La lógica de construcción del payload (`objects` / `deleted_objects`) es idéntica a la de `share_record`, lo que mantiene coherencia en la API.
- No se introducen cambios con ruptura de compatibilidad; los métodos y rutas existentes no se modifican.