### PR TITLE
fix: Manejo de valores None en listas anidadas de _labels y _labels_list

### DIFF
--- a/linkaform_api/lkf_base/base.py
+++ b/linkaform_api/lkf_base/base.py
@@ -117,7 +117,9 @@ class LKF_Base(LKFBaseObject):
     def _labels_list(self, data=[], ids_label_dct={}, from_self=False):
         res = []
         for d in data:
-            if type(d) == list:
+            if d is None:
+                res.append(None)
+            elif type(d) == list:
                 res.append(self._labels_list(d, ids_label_dct=ids_label_dct, from_self=True))
             else:
                 res.append(self._labels(d, ids_label_dct=ids_label_dct, from_self=True))
@@ -132,6 +134,8 @@ class LKF_Base(LKFBaseObject):
                 data = self.answers
         _f = {v:k for k, v in ids_label_dct.items()}
         res = {}
+        if data is None:
+            return None
         if type(data) in (str, int, float):
             return data
         for key, value in data.items():


### PR DESCRIPTION
## ¿Qué cambia?

- En `_labels_list`: se agrega una guarda al inicio del bucle para detectar elementos `None` dentro de la lista de datos; si el elemento es `None`, se añade `None` al resultado en lugar de intentar procesarlo.
- En `_labels`: se agrega una guarda al inicio de la función que retorna `None` inmediatamente si `data` es `None`, evitando que se llame `.items()` sobre un valor nulo.

## ¿Por qué?

En ciertos flujos de datos, las listas anidadas pueden contener valores `None` (por ejemplo, respuestas vacías o campos opcionales no rellenados). Sin estas guardas, el código lanzaba excepciones al intentar iterar o acceder a atributos de un objeto `None`, causando fallos silenciosos o errores en tiempo de ejecución.

## Notas adicionales

- Los cambios son retrocompatibles: el comportamiento existente para valores válidos (`list`, `str`, `int`, `float`, `dict`) no se ve afectado.
- Se preserva la forma de los datos de salida: si la entrada contiene `None`, la salida también lo refleja en la misma posición.