### PR TITLE
Soporte para archivos PDF y data: URLs en _build_image_url

### DIFF
--- a/linkaform_api/integrations/openrouter.py
+++ b/linkaform_api/integrations/openrouter.py
@@ -366,9 +366,13 @@ class OpenRouter(LKFBaseObject):
     def _build_image_url(self, image_source: str) -> str:
         """
         Prepara la URL de la imagen para el payload.
-        - URL remota  → la devuelve tal cual
+        - data: URL  → ya está en base64, se devuelve tal cual
+        - URL remota → se devuelve tal cual
         - Archivo local → convierte a base64
         """
+        if image_source.startswith('data:'):
+            return image_source
+
         if image_source.startswith('http://') or image_source.startswith('https://'):
             return image_source
 
@@ -378,6 +382,7 @@ class OpenRouter(LKFBaseObject):
             '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
             '.png': 'image/png',  '.gif':  'image/gif',
             '.webp': 'image/webp',
+            '.pdf': 'application/pdf',
         }
         media_type = media_types.get(ext, 'image/jpeg')
         with open(image_source, 'rb') as f:


### PR DESCRIPTION
## ¿Qué cambia?

- Se agrega `.pdf` (`application/pdf`) al diccionario de tipos de medios en `_build_image_url`, permitiendo procesar archivos PDF locales como contenido en base64.
- Se agrega un caso de retorno temprano para fuentes que ya comienzan con `data:`, evitando procesamiento innecesario cuando la imagen ya viene codificada en base64.
- Se actualiza el docstring del método para reflejar los tres casos soportados: `data:` URL, URL remota y archivo local.

## ¿Por qué?

Antes, si se pasaba un archivo `.pdf` como fuente local, el método no reconocía su tipo MIME y caía en el fallback `image/jpeg`, generando un payload incorrecto. Además, fuentes que ya venían en formato `data:` (base64 embebido) se intentaban abrir como archivo local, causando un error. Estos dos casos son necesarios para integraciones que envían documentos PDF o imágenes ya codificadas directamente al modelo.